### PR TITLE
Refactor power metrics calculations and standardize variable handling

### DIFF
--- a/collectors/data-orchestrator.js
+++ b/collectors/data-orchestrator.js
@@ -263,7 +263,7 @@ async function generateStatsJson() {
     // Calculate derived values
     const loadW = powerMetrics.load_W || 0;
     const axpBattV = powerMetrics.axp_batt_v_V || 0;
-    const esp32V = powerMetrics.esp32_v_V || null;
+    const esp32V = powerMetrics.esp32_v_V || 0;
     const socPct = Math.round((powerMetrics.soc || 0) * 100);
 
     // Get sparkline data
@@ -279,15 +279,16 @@ async function generateStatsJson() {
       // Power metrics
       load_W: loadW,
       p_in_W: powerMetrics.p_in_W || 0,
-      W: loadW, // Alternative name used by frontend
 
       // Battery metrics - AXP20x PMIC
       axp_batt_v_V: axpBattV,
-      axp_batt_i_A: powerMetrics.axp_batt_i_mA / 1000, // Convert mA to A
+      axp_batt_i_mA: powerMetrics.axp_batt_i_mA || 0,
+      axp_batt_i_A: powerMetrics.axp_batt_i_mA ? powerMetrics.axp_batt_i_mA / 1000 : 0,
       
       // Battery metrics - ESP32 shunt monitor
       esp32_v_V: esp32V,
-      esp32_i_A: powerMetrics.esp32_i_mA ? powerMetrics.esp32_i_mA / 1000 : null, // Convert mA to A
+      esp32_i_mA: powerMetrics.esp32_i_mA || null,
+      esp32_i_A: powerMetrics.esp32_i_mA ? powerMetrics.esp32_i_mA / 1000 : null,
       soc_pct: socPct,
       status: powerMetrics.status || "unknown",
 
@@ -308,7 +309,10 @@ async function generateStatsJson() {
           load_15min: fmt(powerMetrics.cpu_load_15min || 0, 2),
         },
         soc: socPct > 0 ? `${socPct}%` : "—",
-        status: powerMetrics.status || "—"
+        status: powerMetrics.status || "—",
+        axp_batt: {
+          capacity: powerMetrics.axp_batt_capacity ? `${powerMetrics.axp_batt_capacity}%` : "—"
+        }
       }
     };
 

--- a/collectors/power-collector.js
+++ b/collectors/power-collector.js
@@ -103,7 +103,7 @@ function parseAxInput(ue) {
   const online = ue.POWER_SUPPLY_ONLINE === "1";
   const v_uV = safeFloat(ue.POWER_SUPPLY_VOLTAGE_NOW, 1); // µV (raw from sysfs)
   const i_uA = safeFloat(ue.POWER_SUPPLY_CURRENT_NOW, 1); // µA (raw from sysfs)
-  const p_uW = present && online ? v_uV * i_uA : 0; // µW (µV * µA = µW)
+  const p_uW = present && online ? (v_uV * i_uA) * 1e-6 : 0; // µW (µV * µA * 1e-6 = µW)
   return { present, online, v_uV, i_uA, p_uW };
 }
 
@@ -112,7 +112,7 @@ function parseAxBattery(ue) {
   const present = ue.POWER_SUPPLY_PRESENT === "1";
   const v_uV = safeFloat(ue.POWER_SUPPLY_VOLTAGE_NOW, 1); // µV (raw from sysfs)
   const i_uA = safeFloat(ue.POWER_SUPPLY_CURRENT_NOW, 1); // µA (raw from sysfs, charging > 0)
-  const p_uW = present ? v_uV * i_uA : 0; // µW (µV * µA = µW)
+  const p_uW = present ? (v_uV * i_uA) * 1e-6 : 0; // µW (µV * µA * 1e-6 = µW)
   const capacity = safeFloat(ue.POWER_SUPPLY_CAPACITY, 1); // percentage
   const status = ue.POWER_SUPPLY_STATUS || "unknown";
   return { present, v_uV, i_uA, p_uW, capacity, status };

--- a/static/js/components/power-monitor.js
+++ b/static/js/components/power-monitor.js
@@ -60,8 +60,8 @@ class PowerMonitor {
     const loadW = this.safeNumber(data.load_W);
     const axpBattV = this.safeNumber(data.axp_batt_v_V);
     const shuntV = this.safeNumber(data.esp32_v_V);
-    const loadA = this.safeNumber(data.esp32_i_mA) * 1e-3;
-    const socPct = this.safeInt(data.soc);
+    const loadA = this.safeNumber(data.esp32_i_mA);
+    const socPct = this.safeInt(data.soc_pct);
     const cpuTemp = data.cpu_temp_c;
     const cpuLoad = data.cpu_load_15min;
     const backupSoc = this.safeNumber(data.axp_batt_capacity);
@@ -78,7 +78,7 @@ class PowerMonitor {
       ],
       [
         "Current draw",
-        (this.isPresent(loadA) ? this.formatUnit(loadA, "A", 3) : "—") +
+        (this.isPresent(loadA) ? this.formatUnit(loadA, "mA", 4) : "—") +
           (this.isPresent(loadA) ? this.createSparklineSVG(sparklines.currentDraw) : ""),
       ],
       [


### PR DESCRIPTION
- Update data-orchestrator.js to ensure default values for power metrics are set to 0 instead of null, improving data consistency.
- Modify power-collector.js to correctly calculate power in microwatts (µW) by applying the appropriate conversion factor.
- Adjust power-monitor.js to reflect changes in variable names and ensure proper unit formatting for current draw.

These changes enhance the reliability of power data processing and align with the recent variable naming standardization efforts.