### PR TITLE
add back important dir for calendar finding

### DIFF
--- a/static/js/render_calendar.js
+++ b/static/js/render_calendar.js
@@ -96,7 +96,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         // requires js/parse_calendar.js to be run as a cron job on the server
         // only runs intermittently (calendars don't change often) and is more efficient
-        events: "/calendar.json",
+        events: "/api/calendar.json",
         eventDisplay: "list-item",
         eventContent: renderEventContent,
         eventDidMount: function (ev) {


### PR DESCRIPTION
i borked the calendar rendering in #23 because I didn't revert my local testing location for the calendar.json file.

this fixes it!