### PR TITLE
don't use crypto lib to generate uuids for calendar popovers

### DIFF
--- a/static/js/render_calendar.js
+++ b/static/js/render_calendar.js
@@ -53,7 +53,9 @@ function renderEventContent(eventInfo) {
         `;
 
     if (isDayGridMonth) {
-        const uuid = self.crypto.randomUUID();
+        // make a pretty decent alpha numeric uuid string
+        // https://stackoverflow.com/a/8084248
+        const uuid = Math.random().toString(36).substr(2, 9);
         const popoverId = `popover-${uuid}`;
         eventElement = `
             <div class="popover" id="${popoverId}">


### PR DESCRIPTION
ok I learned some things re: websites today -- I don't understand them and I don't really want to.

I saw this error when looking at sequoia.garden after going from index to elsewhere and back to index:
<img width="668" height="322" alt="Screenshot 2025-09-10 at 6 34 15 PM" src="https://github.com/user-attachments/assets/4646a3b9-61e8-4b93-b645-c0827e703720" />

And I don't understand why this isn't triggered on initial page load -- I assume it has to do with the sloppy use of self, but ... the crypto module is still available on `self` after navigation, but for some reason no longer has access to `self/window.crypto.randomUUID`.
<img width="489" height="372" alt="Screenshot 2025-09-10 at 6 36 48 PM" src="https://github.com/user-attachments/assets/311bb532-1378-4bda-a0ac-05c3d41b1334" />

Anyways, not using the crypto module fixes this.