### PR TITLE
Add ESP32 battery monitor logger service

### DIFF
--- a/ansible/sol.yml
+++ b/ansible/sol.yml
@@ -684,7 +684,9 @@
         shell: /bin/false
         system: yes
         create_home: no
-        groups: www-data
+        groups:
+          - www-data
+          - dialout
         append: yes
       tags: [collectors]
 
@@ -721,6 +723,23 @@
         state: present
       tags: [collectors]
 
+    - name: Install Python packages for ESP logger
+      ansible.builtin.apt:
+        name:
+          - python3-serial
+          - python3-paho-mqtt
+        state: present
+      tags: [collectors, esp]
+
+    - name: Create ESP logger log directory
+      ansible.builtin.file:
+        path: /var/log/esp_logger
+        state: directory
+        owner: monitoring
+        group: monitoring
+        mode: "0755"
+      tags: [collectors, esp]
+
     - name: Create collectors subdirectories
       ansible.builtin.file:
         path: "{{ collectors_app_dir }}/{{ item }}"
@@ -739,7 +758,7 @@
         dest: "{{ collectors_app_dir }}/{{ item.dest }}"
         owner: monitoring
         group: monitoring
-        mode: "0644"
+        mode: "0755"
       loop:
         - {
             src: "collectors/power-collector.js",
@@ -756,6 +775,10 @@
         - {
             src: "collectors/data-orchestrator.js",
             dest: "collectors/data-orchestrator.js",
+          }
+        - {
+            src: "collectors/esp_logger.py",
+            dest: "collectors/esp_logger.py",
           }
       tags: [collectors]
 
@@ -784,6 +807,7 @@
         - collectors/systemd/weather-collector.service
         - collectors/systemd/calendar-collector.service
         - collectors/systemd/data-orchestrator.service
+        - collectors/systemd/esp-logger.service
       notify: Reload systemd
       tags: [collectors]
 
@@ -837,6 +861,14 @@
         - data-orchestrator.service
       tags: [collectors]
 
+    - name: Enable and start ESP logger service
+      ansible.builtin.systemd:
+        name: esp-logger.service
+        state: started
+        enabled: yes
+        daemon_reload: yes
+      tags: [collectors, esp]
+
     - name: Configure logrotate for collector logs
       ansible.builtin.copy:
         dest: /etc/logrotate.d/monitoring-collectors
@@ -852,6 +884,23 @@
               create 0644 monitoring monitoring
           }
       tags: [collectors]
+
+    - name: Configure logrotate for ESP logger
+      ansible.builtin.copy:
+        dest: /etc/logrotate.d/esp-logger
+        mode: "0644"
+        content: |
+          /var/log/esp_logger/*.jsonl {
+              daily
+              rotate 30
+              compress
+              delaycompress
+              missingok
+              notifempty
+              create 0644 monitoring monitoring
+              maxsize 100M
+          }
+      tags: [collectors, esp]
 
   handlers:
     - name: Restart ssh

--- a/collectors/esp_logger.py
+++ b/collectors/esp_logger.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# collectors/esp_logger.py
+# Logs ESP32 battery monitor data from serial port to JSONL file
+
+import serial
+import time
+import json
+import sys
+import os
+from datetime import datetime, timezone
+
+SERIAL_PORT = "/dev/ttyUSB0"
+BAUD_RATE = 115200
+LOG_FILE = "/var/log/esp_logger/esp_log.jsonl"
+
+def send_time_sync(ser):
+    """Send current Unix timestamp to ESP32 for time synchronization"""
+    now = int(time.time())
+    packet = json.dumps({"epoch": now}) + "\n"
+    ser.write(packet.encode("utf-8"))
+    print(f"[{datetime.utcnow().isoformat()}Z] Sent time sync: {now}", flush=True)
+
+def ensure_log_dir():
+    """Ensure log directory exists"""
+    log_dir = os.path.dirname(LOG_FILE)
+    os.makedirs(log_dir, exist_ok=True)
+
+def main():
+    ensure_log_dir()
+
+    try:
+        ser = serial.Serial(SERIAL_PORT, BAUD_RATE, timeout=1)
+    except serial.SerialException as e:
+        print(f"[ERROR] Failed to open serial port {SERIAL_PORT}: {e}", file=sys.stderr, flush=True)
+        sys.exit(1)
+
+    time.sleep(2)  # Allow time for serial port to reset the ESP32
+    send_time_sync(ser)
+
+    print(f"[{datetime.utcnow().isoformat()}Z] ESP logger started, writing to {LOG_FILE}", flush=True)
+
+    with open(LOG_FILE, "a") as log:
+        while True:
+            try:
+                line = ser.readline().decode("utf-8").strip()
+                if not line:
+                    continue
+
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    print(f"[WARN] Bad JSON: {line}", flush=True)
+                    continue
+
+                # Add ISO timestamp if not present
+                if "ts" not in msg:
+                    msg["ts"] = datetime.now(timezone.utc).isoformat()
+
+                # Write to local file
+                log.write(json.dumps(msg) + "\n")
+                log.flush()
+
+                # Minimal console output (timestamp every 60 seconds)
+                if int(time.time()) % 60 == 0:
+                    soc = msg.get("soc", 0) * 100
+                    v = msg.get("v", 0)
+                    i = msg.get("i", 0)
+                    print(f"[{msg.get('ts', 'unknown')}] SOC: {soc:.1f}%, V: {v:.2f}V, I: {i:.0f}mA", flush=True)
+
+            except KeyboardInterrupt:
+                print("\n[INFO] Shutting down...", flush=True)
+                break
+            except Exception as e:
+                print(f"[ERROR] {e}", file=sys.stderr, flush=True)
+                time.sleep(1)
+
+    ser.close()
+
+if __name__ == "__main__":
+    main()

--- a/collectors/power-collector.js
+++ b/collectors/power-collector.js
@@ -11,7 +11,6 @@ const os = require("os");
 const LOGS_DIR = "/var/log/monitoring";
 const POWER_LOG_PATH = path.join(LOGS_DIR, "power_metrics.jsonl");
 const ESP32_LOG_PATH = '/var/log/esp_logger/esp_log.jsonl'
-// TODO: update to use path.join(LOGS_DIR, "esp_log.jsonl"); (@orban)
 
 // System sensor paths
 const CPU_TEMP_PATH = "/sys/class/thermal/thermal_zone0/temp";

--- a/collectors/systemd/esp-logger.service
+++ b/collectors/systemd/esp-logger.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=ESP32 Battery Monitor Serial Logger
+After=network.target
+
+[Service]
+Type=simple
+User=monitoring
+Group=dialout
+ExecStart=/usr/bin/python3 /opt/sequoia_fabrica_blog/collectors/esp_logger.py
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+# Ensure log directory exists
+RuntimeDirectory=esp_logger
+RuntimeDirectoryMode=0755
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Problem
The `/power` page shows "No power data available" because the ESP32 battery monitoring data isn't being collected.

## Solution
This PR adds the missing ESP logger service that reads battery monitoring data from the ESP32 via serial port and writes it to a JSONL log file.

## What's Changed

### New Components
- **`collectors/esp_logger.py`**: Python script that reads JSON telemetry from ESP32 (INA228 shunt monitor) over serial port
- **`collectors/systemd/esp-logger.service`**: Systemd service to run esp_logger.py continuously

### Ansible Configuration Updates
- Install Python dependencies: `python3-serial`, `python3-paho-mqtt`
- Add `monitoring` user to `dialout` group (for serial port access)
- Create `/var/log/esp_logger/` directory
- Deploy esp_logger.py script (mode 0755, executable)
- Deploy and enable esp-logger.service
- Configure logrotate for ESP logs (30 day retention, 100MB max size)

### Other Changes
- Remove TODO comment from `power-collector.js` (keeping ESP log path as-is)

## Data Flow

\`\`\`
ESP32 → Serial (/dev/ttyUSB0) → esp_logger.py → /var/log/esp_logger/esp_log.jsonl
                                                           ↓
power-collector.js reads latest metrics → power_metrics.jsonl
                                                           ↓
data-orchestrator.js aggregates → /api/stats.json → Website /power page
\`\`\`

## Testing

After deployment:
1. Check service status: `systemctl status esp-logger`
2. Verify log file exists: `ls -lh /var/log/esp_logger/esp_log.jsonl`
3. Watch live data: `tail -f /var/log/esp_logger/esp_log.jsonl`
4. Check API endpoint: `curl http://sol.cloudforest-perch.ts.net/api/stats.json`
5. Visit https://sequoia.garden/power/ and verify metrics display

Generated with [Claude Code](https://claude.com/claude-code)