### PR TITLE
fix deploy health check for oneshot services

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -91,13 +91,24 @@ jobs:
             sudo systemctl restart calendar-collector.service
 
             sleep 5
-            for service in esp-logger power-collector data-orchestrator weather-collector calendar-collector; do
-              if ! systemctl is-active --quiet $service.service; then
-                echo "ERROR: $service.service failed to start"
+
+            # esp-logger is long-running (Type=simple) — check it's still active
+            if ! systemctl is-active --quiet esp-logger.service; then
+              echo "ERROR: esp-logger.service failed to start"
+              systemctl status esp-logger.service
+              exit 1
+            fi
+
+            # The rest are oneshot (timer-triggered) — they run and exit.
+            # is-active returns inactive for completed oneshots, so use is-failed instead.
+            for service in power-collector data-orchestrator weather-collector calendar-collector; do
+              if systemctl is-failed --quiet $service.service; then
+                echo "ERROR: $service.service failed"
                 systemctl status $service.service
+                journalctl --unit=$service.service --no-pager --lines=20
                 exit 1
               fi
             done
-            echo "All services started successfully"
+            echo "All services healthy"
 
 


### PR DESCRIPTION
## Summary
- The deploy workflow's service health check used `systemctl is-active` for all services, but the collector services (power-collector, data-orchestrator, weather-collector, calendar-collector) are `Type=oneshot` triggered by timers
- A completed oneshot service's normal state is `inactive (dead)` — `is-active` always returns false for these, causing the deploy to fail even when everything worked correctly
- This was the cause of the deploy failure on PR #77 merge

## Changes
- Use `is-active` only for `esp-logger` (the one `Type=simple` long-running service)
- Use `is-failed` for the four oneshot services, which correctly distinguishes "completed successfully" from "actually crashed"
- Added `journalctl` output on failure for easier debugging

## Test plan
- [ ] Merge and verify the deploy workflow passes the health check step